### PR TITLE
修复雅可比矩阵文档中理论定义与代码示例不一致

### DIFF
--- a/02-机器人基础和控制、手眼协调/04速度运动学与雅可比矩阵.md
+++ b/02-机器人基础和控制、手眼协调/04速度运动学与雅可比矩阵.md
@@ -101,7 +101,8 @@ def calculate_jacobian_2link():
     print(f"完整雅可比矩阵 J:\n{J_val}")
     print(f"线速度子矩阵 Jv:\n{Jv_val}")
     print(f"det(Jv) (接近0表示位置奇异): {det_Jv}")
-    print(f"rank(J) = {rank_J} (小于2表示关节速度映射退化)")
+    print(f"rank(J) = {rank_J} (用于判断完整雅可比列秩是否下降；小于2才表示列秩退化)")
+    print("注: 位置任务的奇异性以 Jv 为准（例如 det(Jv) 是否接近 0）。")
 
     # 5. 力映射示例: tau = J^T * F
     # F = [fx, fy, mz]^T, 对应平面力与末端力矩


### PR DESCRIPTION
修复了“04速度运动学与雅可比矩阵”文档中理论定义与代码示例不一致的问题。

核心变更：
1) 更正术语笔误（微分）
2) 将示例雅可比从位置 2x2 升级为位姿 3x2（加入 phi=theta1+theta2）
3) 明确 tau=J^T F 中 F 为平面广义力 [fx, fy, mz]^T
4) 修正奇异性验证方法（非方阵 J 改用 Jv 行列式与 rank）