### PR TITLE
Add GitHub Pages static ebook build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        run: npm run build:pages
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,7 @@ datawhale_eai_pnp_language
 # Local ebook web app dependencies
 node_modules/
 artifacts/
+
+# Keep ebook web shared logic tracked
+!web/lib/
+!web/lib/*.js

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "node web/server.js"
+    "start": "node web/server.js",
+    "build:pages": "node scripts/build-pages.js"
   },
   "dependencies": {
     "cheerio": "^1.1.2",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1,0 +1,153 @@
+"use strict";
+
+const fs = require("fs/promises");
+const fsSync = require("fs");
+const path = require("path");
+const {
+  repoRoot,
+  projectAssetMap,
+  fullPathFromRel,
+  collectCatalog,
+  buildDocPayload,
+  fetchGithubRepo,
+} = require("../web/lib/content");
+
+const distRoot = path.join(repoRoot, "dist");
+const siteRoot = path.join(distRoot, "zh-cn");
+const publicRoot = path.join(repoRoot, "web", "public");
+const katexRoot = path.join(repoRoot, "node_modules", "katex", "dist");
+
+async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function emptyDir(dirPath) {
+  await fs.rm(dirPath, { recursive: true, force: true });
+  await ensureDir(dirPath);
+}
+
+async function copyFilePreserveDir(fromPath, toPath) {
+  await ensureDir(path.dirname(toPath));
+  await fs.copyFile(fromPath, toPath);
+}
+
+async function copyDirectory(source, target) {
+  await ensureDir(target);
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    const fromPath = path.join(source, entry.name);
+    const toPath = path.join(target, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirectory(fromPath, toPath);
+    } else if (entry.isFile()) {
+      await copyFilePreserveDir(fromPath, toPath);
+    }
+  }
+}
+
+function collectFileRefs(value, bucket) {
+  const matches = String(value).match(/files\/([^"'()\s?#]+(?:\?[^"'()\s#]*)?)/g) || [];
+  for (const match of matches) {
+    const relPath = decodeURIComponent(
+      match.replace(/^files\//, "").replace(/\?.*$/, ""),
+    );
+    bucket.add(relPath);
+  }
+}
+
+function collectHomeAssetRefs() {
+  const appSource = fsSync.readFileSync(path.join(publicRoot, "app.js"), "utf8");
+  const refs = new Set();
+  const matches = appSource.matchAll(/\b(?:media|image):\s*"([^"]+)"/g);
+  for (const match of matches) {
+    refs.add(match[1]);
+  }
+  return refs;
+}
+
+async function buildSite() {
+  await emptyDir(distRoot);
+  await ensureDir(siteRoot);
+
+  await copyDirectory(publicRoot, siteRoot);
+  await copyDirectory(katexRoot, path.join(siteRoot, "vendor", "katex"));
+
+  const catalog = await collectCatalog({ withVersion: true });
+  const github = await fetchGithubRepo().catch(() => ({
+    stars: null,
+    forks: null,
+    updatedAt: null,
+  }));
+
+  const dataRoot = path.join(siteRoot, "data");
+  const docsRoot = path.join(dataRoot, "docs");
+  await ensureDir(docsRoot);
+
+  await fs.writeFile(
+    path.join(dataRoot, "catalog.json"),
+    JSON.stringify(catalog, null, 2),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(dataRoot, "github.json"),
+    JSON.stringify(github, null, 2),
+    "utf8",
+  );
+
+  const referencedRepoFiles = collectHomeAssetRefs();
+  Object.values(projectAssetMap).forEach((relPath) => {
+    if (relPath && fsSync.existsSync(fullPathFromRel(relPath))) {
+      referencedRepoFiles.add(relPath);
+    }
+  });
+
+  for (const doc of catalog.docs) {
+    const payload = await buildDocPayload(doc.relPath, catalog, { withVersion: true });
+    collectFileRefs(payload.html, referencedRepoFiles);
+    await fs.writeFile(
+      path.join(docsRoot, `${doc.id}.json`),
+      JSON.stringify(payload),
+      "utf8",
+    );
+  }
+
+  for (const relPath of referencedRepoFiles) {
+    const sourcePath = fullPathFromRel(relPath);
+    if (!fsSync.existsSync(sourcePath)) continue;
+    const stat = fsSync.statSync(sourcePath);
+    if (!stat.isFile()) continue;
+    const toPath = path.join(siteRoot, "files", ...relPath.split("/"));
+    await copyFilePreserveDir(sourcePath, toPath);
+  }
+
+  const faviconRel = projectAssetMap.favicon;
+  if (faviconRel && fsSync.existsSync(fullPathFromRel(faviconRel))) {
+    await copyFilePreserveDir(fullPathFromRel(faviconRel), path.join(siteRoot, "favicon.png"));
+  }
+
+  const rootRedirect = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=./zh-cn/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Every-Embodied</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="./zh-cn/">./zh-cn/</a>...</p>
+  </body>
+</html>
+`;
+
+  const noJekyllPath = path.join(distRoot, ".nojekyll");
+  await fs.writeFile(path.join(distRoot, "index.html"), rootRedirect, "utf8");
+  await fs.writeFile(noJekyllPath, "", "utf8");
+
+  const siteIndex = await fs.readFile(path.join(siteRoot, "index.html"), "utf8");
+  await fs.writeFile(path.join(siteRoot, "404.html"), siteIndex, "utf8");
+}
+
+buildSite().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/lib/content.js
+++ b/web/lib/content.js
@@ -1,0 +1,730 @@
+"use strict";
+
+const fs = require("fs/promises");
+const fsSync = require("fs");
+const path = require("path");
+const MarkdownIt = require("markdown-it");
+const texmath = require("markdown-it-texmath");
+const katex = require("katex");
+const cheerio = require("cheerio");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const collator = new Intl.Collator("zh-Hans-CN", {
+  numeric: true,
+  sensitivity: "base",
+});
+
+const hiddenOrGeneratedDirs = new Set([
+  ".git",
+  ".github",
+  "node_modules",
+  "web",
+  "dist",
+  "__pycache__",
+]);
+
+const supportingDocDirs = new Set([
+  "assets",
+  "asset",
+  "images",
+  "resources",
+  "external-libraries",
+]);
+
+const projectAssetMap = {
+  cover: "assets/main.png",
+  hero: "assets/main.png",
+  homepageHero: "assets/首页背景图.png",
+  logo: "assets/头像 logo.jpg",
+  favicon: "assets/线稿.png",
+  map: "map.png",
+};
+
+const md = new MarkdownIt({
+  html: true,
+  linkify: true,
+  typographer: true,
+  breaks: false,
+});
+
+md.use(texmath, {
+  engine: katex,
+  delimiters: "dollars",
+  katexOptions: {
+    throwOnError: false,
+    strict: "ignore",
+  },
+});
+
+addHeadingIds(md);
+addLinkAndImageResolvers(md);
+
+function toPosix(value) {
+  return value.replace(/\\/g, "/");
+}
+
+function encodePathForUrl(relPath) {
+  return normalizeRelPath(relPath)
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function normalizeRelPath(value) {
+  const normalized = path.posix.normalize(toPosix(value));
+  if (
+    normalized === "." ||
+    normalized.startsWith("../") ||
+    normalized.includes("/../") ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error("Invalid repository path");
+  }
+  return normalized;
+}
+
+function fullPathFromRel(relPath) {
+  const safeRel = normalizeRelPath(relPath);
+  const fullPath = path.resolve(repoRoot, safeRel);
+  const relative = path.relative(repoRoot, fullPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Path escapes repository root");
+  }
+  return fullPath;
+}
+
+function relPathExists(relPath) {
+  try {
+    return fsSync.existsSync(fullPathFromRel(relPath));
+  } catch {
+    return false;
+  }
+}
+
+function idFromRel(relPath) {
+  return Buffer.from(normalizeRelPath(relPath), "utf8").toString("base64url");
+}
+
+function relFromId(id) {
+  const relPath = Buffer.from(id, "base64url").toString("utf8");
+  return normalizeRelPath(relPath);
+}
+
+function safeDecodeUrl(value) {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}
+
+function isExternalUrl(value) {
+  return (
+    /^(https?:)?\/\//i.test(value) ||
+    /^(mailto|tel|data):/i.test(value) ||
+    hasEmail(value.trim())
+  );
+}
+
+function isEnglishPath(relPath) {
+  const lower = relPath.toLowerCase();
+  const parts = lower.split("/");
+  return (
+    parts.includes("en") ||
+    lower.endsWith(".en.md") ||
+    path.posix.basename(lower) === "readme.en.md"
+  );
+}
+
+function isSupportingDocPath(relPath) {
+  return relPath
+    .toLowerCase()
+    .split("/")
+    .some((part) => supportingDocDirs.has(part));
+}
+
+function hasChineseText(text) {
+  const matches = text.match(/[\u3400-\u9fff]/g);
+  return Boolean(matches && matches.length >= 6);
+}
+
+function shouldSkipDirectory(dirName) {
+  return hiddenOrGeneratedDirs.has(dirName.toLowerCase());
+}
+
+function shouldSkipMarkdownFile(relPath) {
+  const lower = relPath.toLowerCase();
+  if (!lower.endsWith(".md")) return true;
+  if (isEnglishPath(relPath)) return true;
+  if (isSupportingDocPath(relPath)) return true;
+  return false;
+}
+
+async function walkMarkdownFiles(directory = repoRoot, relativeBase = "") {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const relPath = relativeBase
+      ? path.posix.join(relativeBase, entry.name)
+      : entry.name;
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (shouldSkipDirectory(entry.name)) continue;
+      files.push(...(await walkMarkdownFiles(fullPath, relPath)));
+      continue;
+    }
+
+    if (entry.isFile() && !shouldSkipMarkdownFile(relPath)) {
+      files.push(normalizeRelPath(relPath));
+    }
+  }
+
+  return files;
+}
+
+async function walkStaticFiles(directory = repoRoot, relativeBase = "") {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const relPath = relativeBase
+      ? path.posix.join(relativeBase, entry.name)
+      : entry.name;
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (shouldSkipDirectory(entry.name)) continue;
+      files.push(...(await walkStaticFiles(fullPath, relPath)));
+      continue;
+    }
+
+    if (entry.isFile() && !entry.name.toLowerCase().endsWith(".md")) {
+      files.push(normalizeRelPath(relPath));
+    }
+  }
+
+  return files;
+}
+
+async function readUtf8(relPath) {
+  return (await fs.readFile(fullPathFromRel(relPath), "utf8")).replace(/^\ufeff/, "");
+}
+
+function stripMarkdownInline(value) {
+  return value
+    .replace(/<[^>]+>/g, "")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_~#>\[\]]/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeMetadataLine(value) {
+  return stripMarkdownInline(value)
+    .replace(/^[#>\s-]+/, "")
+    .replace(/[【】]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasEmail(value) {
+  return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(value);
+}
+
+function isAuthorMetadataLine(line) {
+  const clean = normalizeMetadataLine(line);
+  if (!clean) return false;
+  if (/^作者\s*$/.test(clean)) return true;
+  if (/^作者\s*[:：]/.test(clean) && /(联系方式|联系|邮箱|email|@)/i.test(clean)) {
+    return true;
+  }
+  return /^作者\s*[:：]\s*\S/.test(clean) && clean.length <= 80 && !/[。！？?!]/.test(clean);
+}
+
+function isContactMetadataLine(line) {
+  const clean = normalizeMetadataLine(line);
+  if (!clean) return false;
+  if (hasEmail(clean) && clean.length <= 90) return true;
+  return /^(联系方式|联系邮箱|邮箱|email)\s*[:：]/i.test(clean);
+}
+
+function removeTopAuthorMetadata(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const output = [];
+  let meaningfulLines = 0;
+  let removingAuthorBlock = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    const stillInHeaderArea = index < 16 && meaningfulLines < 6;
+
+    if (stillInHeaderArea && isAuthorMetadataLine(line)) {
+      removingAuthorBlock = true;
+      continue;
+    }
+
+    if (stillInHeaderArea && removingAuthorBlock && (!trimmed || isContactMetadataLine(line))) {
+      continue;
+    }
+
+    if (stillInHeaderArea && isContactMetadataLine(line)) {
+      continue;
+    }
+
+    output.push(line);
+    if (trimmed) {
+      meaningfulLines += 1;
+      removingAuthorBlock = false;
+    }
+  }
+
+  return output.join("\n");
+}
+
+function stripEmojiNoise(value) {
+  return value.replace(/[\u{1f300}-\u{1faff}\u{2600}-\u{27bf}]/gu, "").trim();
+}
+
+function formatSegmentTitle(segment) {
+  return segment
+    .replace(/\.md$/i, "")
+    .replace(/^(\d+)[-_]/, "$1 · ")
+    .replace(/_/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function titleFromPath(relPath) {
+  const parts = relPath.split("/");
+  const filename = parts[parts.length - 1];
+  if (/^readme\.md$/i.test(filename)) {
+    if (parts.length === 1) return "项目首页";
+    return formatSegmentTitle(parts[parts.length - 2]);
+  }
+  return formatSegmentTitle(filename);
+}
+
+function extractHeadingTitle(markdown) {
+  let inFence = false;
+  for (const line of markdown.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (!match) continue;
+    const title = stripEmojiNoise(stripMarkdownInline(match[2]));
+    if (!title || /^(\d+[\s.、]*)?(简介|引言|概述|overview)$/i.test(title)) {
+      continue;
+    }
+    return title;
+  }
+  return "";
+}
+
+function extractExcerpt(markdown) {
+  let inFence = false;
+  for (const line of markdown.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (
+      inFence ||
+      !trimmed ||
+      trimmed.startsWith("#") ||
+      trimmed.startsWith("|") ||
+      trimmed.startsWith("<") ||
+      trimmed.startsWith("!") ||
+      trimmed.length < 16
+    ) {
+      continue;
+    }
+    const text = stripMarkdownInline(trimmed);
+    if (hasChineseText(text)) return text.slice(0, 110);
+  }
+  return "";
+}
+
+function slugify(value, fallback = "section") {
+  const clean = stripMarkdownInline(value)
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}\s_-]+/gu, "")
+    .trim()
+    .replace(/\s+/g, "-");
+
+  return clean || fallback;
+}
+
+function uniqueSlug(value, seen, fallback) {
+  const base = slugify(value, fallback);
+  const count = seen.get(base) || 0;
+  seen.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+}
+
+function extractHeadings(markdown) {
+  const headings = [];
+  const seen = new Map();
+  let inFence = false;
+
+  for (const line of markdown.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (!match) continue;
+    const text = stripMarkdownInline(match[2]);
+    if (!text) continue;
+
+    headings.push({
+      id: uniqueSlug(text, seen, `section-${headings.length + 1}`),
+      level: match[1].length,
+      text,
+    });
+  }
+
+  return headings;
+}
+
+function addHeadingIds(markdownIt) {
+  markdownIt.core.ruler.push("heading_ids", (state) => {
+    const seen = new Map();
+    for (let index = 0; index < state.tokens.length - 1; index += 1) {
+      const token = state.tokens[index];
+      const inline = state.tokens[index + 1];
+      if (token.type !== "heading_open" || inline.type !== "inline") continue;
+      const text = stripMarkdownInline(inline.content);
+      const id = uniqueSlug(text, seen, `section-${index}`);
+      token.attrSet("id", id);
+      token.attrJoin("class", "doc-heading");
+    }
+  });
+}
+
+function splitLocalHref(href) {
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) {
+    return { filePart: href, anchor: "" };
+  }
+  return {
+    filePart: href.slice(0, hashIndex),
+    anchor: href.slice(hashIndex + 1),
+  };
+}
+
+function tryResolveAbsoluteLocalPath(targetPath) {
+  const normalized = targetPath.replace(/\\/g, "/");
+  if (!/^[a-zA-Z]:\//.test(normalized) && !normalized.startsWith("/")) {
+    return "";
+  }
+
+  const parts = normalized.split("/").filter(Boolean);
+  for (let index = 0; index < parts.length; index += 1) {
+    const candidate = parts.slice(index).join("/");
+    if (relPathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "";
+}
+
+function resolveRepoRelative(currentRelPath, targetPath) {
+  const decoded = safeDecodeUrl(targetPath).replace(/\\/g, "/");
+  const absoluteCandidate = tryResolveAbsoluteLocalPath(decoded);
+  if (absoluteCandidate) {
+    return normalizeRelPath(absoluteCandidate);
+  }
+  const currentDir = path.posix.dirname(currentRelPath);
+  return normalizeRelPath(path.posix.join(currentDir, decoded));
+}
+
+function fileHrefFromRel(relPath, options = {}) {
+  const safeRel = normalizeRelPath(relPath);
+  if (!relPathExists(safeRel)) {
+    return "#";
+  }
+  const encoded = encodePathForUrl(safeRel);
+  const version = options.withVersion === false ? "" : `?v=${Math.round(fsSync.statSync(fullPathFromRel(safeRel)).mtimeMs)}`;
+  return `files/${encoded}${version}`;
+}
+
+function resolveHref(href, currentRelPath, options = {}) {
+  if (!href) return { href };
+  if (isExternalUrl(href)) return { href, external: true };
+
+  const { filePart, anchor } = splitLocalHref(href);
+  if (!filePart) {
+    const currentId = idFromRel(currentRelPath);
+    return {
+      href: `#/doc/${currentId}${anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""}`,
+      internal: true,
+    };
+  }
+
+  const targetRel = resolveRepoRelative(currentRelPath, filePart);
+  const lower = targetRel.toLowerCase();
+  if (lower.endsWith(".md")) {
+    if (isEnglishPath(targetRel)) {
+      return {
+        href: "#",
+        disabled: true,
+        title: "当前阅读器只收录中文 Markdown 正文",
+      };
+    }
+    return {
+      href: `#/doc/${idFromRel(targetRel)}${anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""}`,
+      internal: true,
+    };
+  }
+
+  return { href: fileHrefFromRel(targetRel, options), asset: true };
+}
+
+function addLinkAndImageResolvers(markdownIt) {
+  const defaultLinkOpen =
+    markdownIt.renderer.rules.link_open ||
+    ((tokens, idx, renderOptions, env, self) => self.renderToken(tokens, idx, renderOptions));
+  const defaultImage =
+    markdownIt.renderer.rules.image ||
+    ((tokens, idx, renderOptions, env, self) => self.renderToken(tokens, idx, renderOptions));
+
+  markdownIt.renderer.rules.link_open = (tokens, idx, renderOptions, env, self) => {
+    const token = tokens[idx];
+    const href = token.attrGet("href");
+    const resolved = resolveHref(href, env.relPath, env.linkOptions);
+    token.attrSet("href", resolved.href);
+    if (resolved.external) {
+      token.attrSet("target", "_blank");
+      token.attrSet("rel", "noopener noreferrer");
+    }
+    if (resolved.disabled) {
+      token.attrJoin("class", "disabled-link");
+      token.attrSet("aria-disabled", "true");
+      token.attrSet("title", resolved.title);
+    }
+    return defaultLinkOpen(tokens, idx, renderOptions, env, self);
+  };
+
+  markdownIt.renderer.rules.image = (tokens, idx, renderOptions, env, self) => {
+    const token = tokens[idx];
+    const src = token.attrGet("src");
+    if (src && !isExternalUrl(src)) {
+      const resolved = resolveHref(src, env.relPath, env.linkOptions);
+      token.attrSet("src", resolved.href);
+    }
+    token.attrSet("loading", "lazy");
+    return defaultImage(tokens, idx, renderOptions, env, self);
+  };
+}
+
+function transformRenderedHtml(html, currentRelPath, options = {}) {
+  const $ = cheerio.load(html, { decodeEntities: false }, false);
+
+  $("img, source").each((_, element) => {
+    const node = $(element);
+    const attrName = node.attr("src") ? "src" : "srcset";
+    const value = node.attr(attrName);
+    if (!value || isExternalUrl(value) || value.startsWith("files/")) return;
+    const resolved = resolveHref(value, currentRelPath, options);
+    node.attr(attrName, resolved.href);
+    if (element.tagName === "img" && !node.attr("loading")) {
+      node.attr("loading", "lazy");
+    }
+  });
+
+  $("a").each((_, element) => {
+    const node = $(element);
+    const href = node.attr("href");
+    if (!href || href.startsWith("#/doc/") || href.startsWith("files/")) return;
+    const resolved = resolveHref(href, currentRelPath, options);
+    node.attr("href", resolved.href);
+    if (resolved.external) {
+      node.attr("target", "_blank");
+      node.attr("rel", "noopener noreferrer");
+    }
+    if (resolved.disabled) {
+      node.addClass("disabled-link");
+      node.attr("aria-disabled", "true");
+      node.attr("title", resolved.title);
+    }
+  });
+
+  $("table").each((_, element) => {
+    const table = $(element);
+    if (!table.parent().hasClass("table-wrap")) {
+      table.wrap('<div class="table-wrap"></div>');
+    }
+  });
+
+  return $.html();
+}
+
+function groupForDoc(relPath) {
+  if (relPath === "README.md") {
+    return {
+      key: "__root__",
+      title: "项目首页",
+      sortTitle: "00-项目首页",
+    };
+  }
+
+  const first = relPath.split("/")[0];
+  return {
+    key: first,
+    title: formatSegmentTitle(first),
+    sortTitle: first,
+  };
+}
+
+function catalogSortPath(relPath) {
+  return relPath === "README.md" ? "00-README.md" : relPath;
+}
+
+async function collectCatalog(options = {}) {
+  const files = await walkMarkdownFiles();
+  const docs = [];
+
+  for (const relPath of files) {
+    const markdown = await readUtf8(relPath);
+    if (!hasChineseText(markdown)) continue;
+
+    const group = groupForDoc(relPath);
+    const title = extractHeadingTitle(markdown) || titleFromPath(relPath);
+    docs.push({
+      id: idFromRel(relPath),
+      relPath,
+      title,
+      groupKey: group.key,
+      groupTitle: group.title,
+      groupSortTitle: group.sortTitle,
+      excerpt: extractExcerpt(markdown),
+      depth: Math.max(0, relPath.split("/").length - 1),
+      dirname: path.posix.dirname(relPath) === "." ? "" : path.posix.dirname(relPath),
+    });
+  }
+
+  docs.sort((left, right) =>
+    collator.compare(catalogSortPath(left.relPath), catalogSortPath(right.relPath)),
+  );
+
+  docs.forEach((doc, index) => {
+    doc.order = index + 1;
+    doc.previousId = docs[index - 1]?.id || "";
+    doc.nextId = docs[index + 1]?.id || "";
+  });
+
+  const groupMap = new Map();
+  for (const doc of docs) {
+    if (!groupMap.has(doc.groupKey)) {
+      groupMap.set(doc.groupKey, {
+        key: doc.groupKey,
+        title: doc.groupTitle,
+        sortTitle: doc.groupSortTitle,
+        docs: [],
+      });
+    }
+    groupMap.get(doc.groupKey).docs.push(doc);
+  }
+
+  const groups = Array.from(groupMap.values()).sort((left, right) =>
+    collator.compare(left.sortTitle, right.sortTitle),
+  );
+
+  const project = {
+    title: "Every-Embodied 电子书",
+    subtitle: "从 0 到 1 走进具身智能",
+  };
+
+  for (const [key, relPath] of Object.entries(projectAssetMap)) {
+    if (fsSync.existsSync(fullPathFromRel(relPath))) {
+      project[key] = fileHrefFromRel(relPath, options);
+    } else {
+      project[key] = "";
+    }
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    project,
+    stats: {
+      docs: docs.length,
+      groups: groups.length,
+    },
+    groups,
+    docs,
+  };
+}
+
+async function buildDocPayload(relPath, catalog, options = {}) {
+  const safeRel = normalizeRelPath(relPath);
+  const doc = catalog.docs.find((item) => item.relPath === safeRel);
+  if (!doc) {
+    throw new Error("Document not found in Chinese catalog");
+  }
+
+  const markdown = await readUtf8(safeRel);
+  const displayMarkdown = removeTopAuthorMetadata(markdown);
+  const rendered = md.render(displayMarkdown, {
+    relPath: safeRel,
+    linkOptions: options,
+  });
+
+  return {
+    ...doc,
+    html: transformRenderedHtml(rendered, safeRel, options),
+    headings: extractHeadings(displayMarkdown),
+  };
+}
+
+async function fetchGithubRepo() {
+  const response = await fetch("https://api.github.com/repos/datawhalechina/every-embodied", {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "every-embodied-reader",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status}`);
+  }
+
+  const repo = await response.json();
+  return {
+    stars: repo.stargazers_count,
+    forks: repo.forks_count,
+    updatedAt: repo.updated_at,
+  };
+}
+
+module.exports = {
+  repoRoot,
+  projectAssetMap,
+  normalizeRelPath,
+  fullPathFromRel,
+  idFromRel,
+  relFromId,
+  encodePathForUrl,
+  fileHrefFromRel,
+  walkStaticFiles,
+  collectCatalog,
+  buildDocPayload,
+  fetchGithubRepo,
+};

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -37,11 +37,12 @@ const els = {
 };
 
 const homeTitleLines = ["从 0 到 1，", "走进具身智能。"];
+const GITHUB_REPO_URL = "https://github.com/datawhalechina/every-embodied";
 
 const homeDemos = [
   {
     title: "项目快速入门",
-    subtitle: "基于 mujoco 一键了解项目基础",
+    subtitle: "基于 Mujoco 一键了解项目基础",
     media: "assets/quick_start.gif",
     doc: "examples/README.md",
   },
@@ -131,7 +132,7 @@ const homeModules = [
         doc: "02-机器人基础和控制、手眼协调/02机器人运动学与 DH 参数.md",
       },
       {
-        title: "VLA 相关总结综述",
+        title: "VLA 综述",
         copy: "理解视觉语言动作模型如何连接感知与控制。",
         image: "assets/libero.gif",
         doc: "06-策略抓取或抓取VLA/01VLA相关总结综述.md",
@@ -208,10 +209,6 @@ function escapeHtml(value) {
     .replace(/"/g, "&quot;");
 }
 
-function docHash(id, anchor = "") {
-  return `#/doc/${id}${anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""}`;
-}
-
 function idFromRelPath(relPath) {
   return btoa(unescape(encodeURIComponent(relPath)))
     .replace(/\+/g, "-")
@@ -219,8 +216,20 @@ function idFromRelPath(relPath) {
     .replace(/=+$/g, "");
 }
 
-function rawHref(relPath) {
-  return `/raw/${idFromRelPath(relPath)}`;
+function encodePathForUrl(relPath) {
+  return relPath
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function fileHref(relPath) {
+  return `files/${encodePathForUrl(relPath)}`;
+}
+
+function docHash(id, anchor = "") {
+  return `#/doc/${id}${anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""}`;
 }
 
 function setIconHref(selector, href) {
@@ -232,8 +241,8 @@ function setIconHref(selector, href) {
 
 function formatCompactNumber(value) {
   if (!Number.isFinite(value)) return "--";
-  if (value >= 1000000) return `${(value / 1000000).toFixed(1).replace(/\\.0$/, "")}m`;
-  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\\.0$/, "")}k`;
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1).replace(/\.0$/, "")}m`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}k`;
   return String(value);
 }
 
@@ -246,10 +255,12 @@ function getRoute() {
   if (hash === "#/" || hash === "#") {
     return { type: "home" };
   }
+
   const homeMatch = hash.match(/^#\/home(?:\/([^?]+))?$/);
   if (homeMatch) {
     return { type: "home", anchor: homeMatch[1] || "" };
   }
+
   if (hash === "#homeDemos" || hash === "#homePaths" || /^#module-/.test(hash)) {
     return { type: "home", anchor: hash.slice(1) };
   }
@@ -299,12 +310,19 @@ function openSidebar() {
   els.scrim.classList.add("open");
 }
 
+async function fetchJson(relPath) {
+  const response = await fetch(relPath, { cache: "no-cache" });
+  if (!response.ok) {
+    throw new Error(`读取失败: ${relPath}`);
+  }
+  return response.json();
+}
+
 async function fetchCatalog() {
   els.catalogStatus.textContent = "扫描 Markdown 中";
-  const response = await fetch("/api/docs");
-  if (!response.ok) throw new Error("目录读取失败");
-  state.catalog = await response.json();
+  state.catalog = await fetchJson("data/catalog.json");
   state.flatDocs = state.catalog.docs;
+
   if (state.catalog.project?.logo) {
     els.brandLogo.src = state.catalog.project.logo;
   }
@@ -312,6 +330,7 @@ async function fetchCatalog() {
     setIconHref('link[rel="icon"]', state.catalog.project.favicon);
     setIconHref('link[rel="apple-touch-icon"]', state.catalog.project.favicon);
   }
+
   els.topMeta.textContent = `${state.catalog.stats.groups} 组 · ${state.catalog.stats.docs} 篇文档`;
   els.catalogStatus.textContent = `已自动识别 ${state.catalog.stats.docs} 篇`;
   renderNav();
@@ -321,9 +340,7 @@ async function fetchCatalog() {
 
 async function fetchGithubStats() {
   try {
-    const response = await fetch("/api/github");
-    if (!response.ok) throw new Error("GitHub stats unavailable");
-    const stats = await response.json();
+    const stats = await fetchJson("data/github.json");
     els.starCount.textContent = formatCompactNumber(Number(stats.stars));
   } catch {
     els.starCount.textContent = "--";
@@ -345,7 +362,7 @@ function renderNav() {
   els.navTree.innerHTML =
     groups
       .map((group) => {
-        const isOpen = keyword || state.openGroups.has(group.key);
+        const isOpen = Boolean(keyword) || state.openGroups.has(group.key);
         return `
           <section class="nav-group">
             <button class="nav-group-toggle" type="button" data-group="${escapeHtml(group.key)}" aria-expanded="${isOpen ? "true" : "false"}">
@@ -464,7 +481,7 @@ function renderHome() {
       return `
         <a class="home-demo-card" href="${doc ? docHash(doc.id) : "#/book"}">
           <span class="home-demo-media">
-            <img src="${rawHref(demo.media)}" alt="${escapeHtml(demo.title)}" loading="lazy" />
+            <img src="${fileHref(demo.media)}" alt="${escapeHtml(demo.title)}" loading="lazy" />
           </span>
           <span class="home-demo-copy">
             <strong>${escapeHtml(demo.title)}</strong>
@@ -492,7 +509,7 @@ function renderHome() {
                 return `
                   <a class="home-module-card" href="${doc ? docHash(doc.id) : "#/book?catalog=1"}">
                     <span class="home-module-media">
-                      <img src="${rawHref(card.image)}" alt="${escapeHtml(card.title)}" loading="lazy" />
+                      <img src="${fileHref(card.image)}" alt="${escapeHtml(card.title)}" loading="lazy" />
                     </span>
                     <span class="home-module-card-body">
                       <small>${String(index + 1).padStart(2, "0")}</small>
@@ -573,9 +590,11 @@ async function loadDoc(id, anchor = "", options = {}) {
   setHomeTitleText();
   setMode("book");
   els.article.innerHTML = '<div class="loading">正在加载 Markdown 内容。</div>';
-  const response = await fetch(`/api/doc/${id}`);
+
+  const response = await fetch(`data/docs/${id}.json`, { cache: "no-cache" });
   if (!response.ok) {
-    els.article.innerHTML = '<div class="error-box">这篇文档不在目录中，可能是英文文档、资源说明或已被移动。</div>';
+    els.article.innerHTML =
+      '<div class="error-box">这篇文档不在目录中，可能是英文文档、资源说明或已被移动。</div>';
     return;
   }
 

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -4,11 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Every-Embodied 电子书</title>
-    <link rel="icon" type="image/png" href="/raw/YXNzZXRzL-e6v-eovy5wbmc?v=1776084187000" />
-    <link rel="apple-touch-icon" href="/raw/YXNzZXRzL-e6v-eovy5wbmc?v=1776084187000" />
-    <link rel="preload" as="image" href="/raw/YXNzZXRzL-mmlumhteiDjOaZr-Wbvi5wbmc?v=1776084112000" />
-    <link rel="stylesheet" href="/vendor/katex/katex.min.css" />
-    <link rel="stylesheet" href="/styles.css" />
+    <link rel="icon" type="image/png" href="./favicon.png" />
+    <link rel="apple-touch-icon" href="./favicon.png" />
+    <link rel="stylesheet" href="./vendor/katex/katex.min.css" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body class="app-booting">
     <header class="topbar">
@@ -17,9 +16,9 @@
         <span></span>
         <span></span>
       </button>
-      <a class="brand" href="#/" aria-label="回到项目首页">
+      <a class="brand" href="#/" aria-label="回到首页">
         <span class="brand-mark">
-          <img id="brandLogo" src="/raw/YXNzZXRzL-WktOWDjyBsb2dvLmpwZw" alt="Every-Embodied logo" />
+          <img id="brandLogo" src="./favicon.png" alt="Every-Embodied logo" />
         </span>
         <span>
           <strong>Every-Embodied</strong>
@@ -27,7 +26,7 @@
         </span>
       </a>
       <nav class="top-links" aria-label="快速入口">
-        <a href="#/" id="homeLink">首页</a>
+        <a href="#/">首页</a>
         <a href="#/home/module-navigation">导航模型</a>
         <a href="#/home/module-operation">操作模型</a>
         <a href="#/home/module-world">世界模型</a>
@@ -36,7 +35,14 @@
         <a href="https://github.com/datawhalechina/every-embodied" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
       <div class="top-meta" id="topMeta">正在读取目录</div>
-      <a class="star-pill" id="starPill" href="https://github.com/datawhalechina/every-embodied" target="_blank" rel="noopener noreferrer" aria-label="GitHub stars">
+      <a
+        class="star-pill"
+        id="starPill"
+        href="https://github.com/datawhalechina/every-embodied"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="GitHub stars"
+      >
         <span class="star-icon">★</span>
         <span>Starred</span>
         <strong id="starCount">--</strong>
@@ -63,11 +69,14 @@
       <main class="reader" id="reader">
         <section class="home-page" id="homePage" hidden>
           <section class="home-hero" aria-labelledby="homeTitle">
-            <img class="home-hero-image" id="homeHeroImage" alt="Every-Embodied 课程封面" />
+            <img class="home-hero-image" id="homeHeroImage" alt="Every-Embodied 首页背景" />
             <div class="home-hero-shade"></div>
             <div class="home-hero-copy">
               <p class="home-kicker">Every-Embodied</p>
-              <h1 id="homeTitle" aria-label="从 0 到 1，走进具身智能。"><span>从 0 到 1，</span><span>走进具身智能。</span></h1>
+              <h1 id="homeTitle" aria-label="从 0 到 1，走进具身智能。">
+                <span>从 0 到 1，</span>
+                <span>走进具身智能。</span>
+              </h1>
               <p>机器人基础、仿真工具、视觉感知、VLA、导航与复现路线，一本电子书连起来。</p>
               <div class="home-actions">
                 <a class="home-button primary" href="#/book">进一步了解</a>
@@ -105,7 +114,7 @@
             <h1 id="docTitle">正在加载</h1>
           </div>
           <div class="reader-actions">
-            <button class="control-button" id="toggleCatalog" type="button">章节总览</button>
+            <button class="control-button" id="toggleCatalog" type="button">展开章节总览</button>
             <button class="control-button" id="refreshCatalog" type="button">刷新目录</button>
           </div>
         </section>
@@ -114,14 +123,14 @@
           <div class="overview-copy">
             <p class="eyebrow">学习导航</p>
             <h2>按文件夹自动排布</h2>
-            <p>新增或移动 Markdown 后，刷新页面即可同步目录。</p>
+            <p>新增或移动 Markdown 后，重新构建即可同步目录。</p>
           </div>
           <div class="overview-grid" id="overviewGrid"></div>
         </section>
 
         <article class="article" id="article" aria-live="polite"></article>
 
-        <nav class="pager" aria-label="上一篇下一篇">
+        <nav class="pager" aria-label="上一篇和下一篇">
           <a class="pager-link" id="prevLink" href="#"></a>
           <a class="pager-link" id="nextLink" href="#"></a>
         </nav>
@@ -136,6 +145,6 @@
     </div>
 
     <div class="scrim" id="scrim"></div>
-    <script src="/app.js" defer></script>
+    <script src="./app.js" defer></script>
   </body>
 </html>

--- a/web/server.js
+++ b/web/server.js
@@ -1,625 +1,43 @@
-const fs = require("fs/promises");
-const fsSync = require("fs");
+"use strict";
+
 const path = require("path");
 const express = require("express");
-const MarkdownIt = require("markdown-it");
-const texmath = require("markdown-it-texmath");
-const katex = require("katex");
-const cheerio = require("cheerio");
+const {
+  repoRoot,
+  fullPathFromRel,
+  normalizeRelPath,
+  collectCatalog,
+  buildDocPayload,
+  fetchGithubRepo,
+} = require("./lib/content");
 
-const repoRoot = path.resolve(__dirname, "..");
 const publicRoot = path.join(__dirname, "public");
 const port = Number(process.env.PORT || 5178);
-const collator = new Intl.Collator("zh-Hans-CN", {
-  numeric: true,
-  sensitivity: "base",
-});
-
-const hiddenOrGeneratedDirs = new Set([
-  ".git",
-  ".github",
-  "node_modules",
-  "web",
-  "__pycache__",
-]);
-const supportingDocDirs = new Set([
-  "assets",
-  "asset",
-  "images",
-  "resources",
-  "external-libraries",
-]);
-
-const md = new MarkdownIt({
-  html: true,
-  linkify: true,
-  typographer: true,
-  breaks: false,
-});
-
-md.use(texmath, {
-  engine: katex,
-  delimiters: "dollars",
-  katexOptions: {
-    throwOnError: false,
-    strict: "ignore",
-  },
-});
-
-addHeadingIds(md);
-addLinkAndImageResolvers(md);
 
 let githubRepoCache = {
   value: null,
   expiresAt: 0,
 };
 
-function toPosix(value) {
-  return value.replace(/\\/g, "/");
-}
-
-function normalizeRelPath(value) {
-  const normalized = path.posix.normalize(toPosix(value));
-  if (
-    normalized === "." ||
-    normalized.startsWith("../") ||
-    normalized.includes("/../") ||
-    path.posix.isAbsolute(normalized)
-  ) {
-    throw new Error("Invalid repository path");
-  }
-  return normalized;
-}
-
-function fullPathFromRel(relPath) {
-  const safeRel = normalizeRelPath(relPath);
-  const fullPath = path.resolve(repoRoot, safeRel);
-  const relative = path.relative(repoRoot, fullPath);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
-    throw new Error("Path escapes repository root");
-  }
-  return fullPath;
-}
-
-function idFromRel(relPath) {
-  return Buffer.from(normalizeRelPath(relPath), "utf8").toString("base64url");
-}
-
-function rawHrefFromRel(relPath) {
-  const fullPath = fullPathFromRel(relPath);
-  const version = fsSync.existsSync(fullPath)
-    ? Math.round(fsSync.statSync(fullPath).mtimeMs)
-    : Date.now();
-  return `/raw/${idFromRel(relPath)}?v=${version}`;
-}
-
-function relFromId(id) {
-  const relPath = Buffer.from(id, "base64url").toString("utf8");
-  return normalizeRelPath(relPath);
-}
-
-function safeDecodeUrl(value) {
-  try {
-    return decodeURI(value);
-  } catch {
-    return value;
-  }
-}
-
-function isExternalUrl(value) {
-  return /^(https?:)?\/\//i.test(value) || /^(mailto|tel|data):/i.test(value);
-}
-
-function isEnglishPath(relPath) {
-  const lower = relPath.toLowerCase();
-  const parts = lower.split("/");
-  return (
-    parts.includes("en") ||
-    lower.endsWith(".en.md") ||
-    path.posix.basename(lower) === "readme.en.md"
-  );
-}
-
-function isSupportingDocPath(relPath) {
-  return relPath
-    .toLowerCase()
-    .split("/")
-    .some((part) => supportingDocDirs.has(part));
-}
-
-function hasChineseText(text) {
-  const matches = text.match(/[\u3400-\u9fff]/g);
-  return Boolean(matches && matches.length >= 6);
-}
-
-function shouldSkipDirectory(dirName) {
-  return hiddenOrGeneratedDirs.has(dirName.toLowerCase());
-}
-
-function shouldSkipMarkdownFile(relPath) {
-  const lower = relPath.toLowerCase();
-  if (!lower.endsWith(".md")) return true;
-  if (isEnglishPath(relPath)) return true;
-  if (isSupportingDocPath(relPath)) return true;
-  return false;
-}
-
-async function walkMarkdownFiles(directory = repoRoot, relativeBase = "") {
-  const entries = await fs.readdir(directory, { withFileTypes: true });
-  const files = [];
-
-  for (const entry of entries) {
-    if (entry.isSymbolicLink()) continue;
-    const relPath = relativeBase
-      ? path.posix.join(relativeBase, entry.name)
-      : entry.name;
-    const fullPath = path.join(directory, entry.name);
-
-    if (entry.isDirectory()) {
-      if (shouldSkipDirectory(entry.name)) continue;
-      files.push(...(await walkMarkdownFiles(fullPath, relPath)));
-      continue;
-    }
-
-    if (entry.isFile() && !shouldSkipMarkdownFile(relPath)) {
-      files.push(normalizeRelPath(relPath));
-    }
-  }
-
-  return files;
-}
-
-async function readUtf8(relPath) {
-  return (await fs.readFile(fullPathFromRel(relPath), "utf8")).replace(/^\ufeff/, "");
-}
-
-function stripMarkdownInline(value) {
-  return value
-    .replace(/<[^>]+>/g, "")
-    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/[`*_~#>\[\]]/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function normalizeMetadataLine(value) {
-  return stripMarkdownInline(value)
-    .replace(/^[#>\s-]+/, "")
-    .replace(/[【】]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function hasEmail(value) {
-  return /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(value);
-}
-
-function isAuthorMetadataLine(line) {
-  const raw = line.trim();
-  const clean = normalizeMetadataLine(raw);
-  if (!clean) return false;
-  if (/^作者\s*$/.test(clean)) return true;
-  if (/^作者\s*[：:]/.test(clean) && /(联系方式|联系|邮箱|email|@)/i.test(clean)) {
-    return true;
-  }
-  return /^作者\s*[：:]\s*\S/.test(clean) && clean.length <= 80 && !/[。！？.!?]/.test(clean);
-}
-
-function isContactMetadataLine(line) {
-  const clean = normalizeMetadataLine(line);
-  if (!clean) return false;
-  if (hasEmail(clean) && clean.length <= 90) return true;
-  return /^(联系方式|联系邮箱|邮箱|email)\s*[：:]/i.test(clean);
-}
-
-function removeTopAuthorMetadata(markdown) {
-  const lines = markdown.split(/\r?\n/);
-  const output = [];
-  let meaningfulLines = 0;
-  let removingAuthorBlock = false;
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    const trimmed = line.trim();
-    const stillInHeaderArea = index < 16 && meaningfulLines < 6;
-
-    if (stillInHeaderArea && isAuthorMetadataLine(line)) {
-      removingAuthorBlock = true;
-      continue;
-    }
-
-    if (stillInHeaderArea && removingAuthorBlock && (!trimmed || isContactMetadataLine(line))) {
-      continue;
-    }
-
-    if (stillInHeaderArea && isContactMetadataLine(line)) {
-      continue;
-    }
-
-    output.push(line);
-    if (trimmed) {
-      meaningfulLines += 1;
-      removingAuthorBlock = false;
-    }
-  }
-
-  return output.join("\n");
-}
-
-function stripEmojiNoise(value) {
-  return value.replace(/[\u{1f300}-\u{1faff}\u{2600}-\u{27bf}]/gu, "").trim();
-}
-
-function formatSegmentTitle(segment) {
-  return segment
-    .replace(/\.md$/i, "")
-    .replace(/^(\d+)[-_]/, "$1 · ")
-    .replace(/_/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function titleFromPath(relPath) {
-  const parts = relPath.split("/");
-  const filename = parts[parts.length - 1];
-  if (/^readme\.md$/i.test(filename)) {
-    if (parts.length === 1) return "项目首页";
-    return formatSegmentTitle(parts[parts.length - 2]);
-  }
-  return formatSegmentTitle(filename);
-}
-
-function extractHeadingTitle(markdown) {
-  let inFence = false;
-  for (const line of markdown.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
-    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
-    if (!match) continue;
-    const title = stripEmojiNoise(stripMarkdownInline(match[2]));
-    if (!title || /^(\d+[\s.、-]*)?(简介|引言|概述|overview)$/i.test(title)) {
-      continue;
-    }
-    return title;
-  }
-  return "";
-}
-
-function extractExcerpt(markdown) {
-  let inFence = false;
-  for (const line of markdown.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (
-      inFence ||
-      !trimmed ||
-      trimmed.startsWith("#") ||
-      trimmed.startsWith("|") ||
-      trimmed.startsWith("<") ||
-      trimmed.startsWith("!") ||
-      trimmed.length < 16
-    ) {
-      continue;
-    }
-    const text = stripMarkdownInline(trimmed);
-    if (hasChineseText(text)) return text.slice(0, 110);
-  }
-  return "";
-}
-
-function slugify(value, fallback = "section") {
-  const clean = stripMarkdownInline(value)
-    .normalize("NFKD")
-    .toLowerCase()
-    .replace(/[^\p{Letter}\p{Number}\s_-]+/gu, "")
-    .trim()
-    .replace(/\s+/g, "-");
-
-  return clean || fallback;
-}
-
-function uniqueSlug(value, seen, fallback) {
-  const base = slugify(value, fallback);
-  const count = seen.get(base) || 0;
-  seen.set(base, count + 1);
-  return count === 0 ? base : `${base}-${count + 1}`;
-}
-
-function extractHeadings(markdown) {
-  const headings = [];
-  const seen = new Map();
-  let inFence = false;
-
-  for (const line of markdown.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (/^```/.test(trimmed) || /^~~~/.test(trimmed)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
-    const match = line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
-    if (!match) continue;
-    const text = stripMarkdownInline(match[2]);
-    if (!text) continue;
-
-    headings.push({
-      id: uniqueSlug(text, seen, `section-${headings.length + 1}`),
-      level: match[1].length,
-      text,
-    });
-  }
-
-  return headings;
-}
-
-function addHeadingIds(markdownIt) {
-  markdownIt.core.ruler.push("heading_ids", (state) => {
-    const seen = new Map();
-    for (let index = 0; index < state.tokens.length - 1; index += 1) {
-      const token = state.tokens[index];
-      const inline = state.tokens[index + 1];
-      if (token.type !== "heading_open" || inline.type !== "inline") continue;
-      const text = stripMarkdownInline(inline.content);
-      const id = uniqueSlug(text, seen, `section-${index}`);
-      token.attrSet("id", id);
-      token.attrJoin("class", "doc-heading");
-    }
-  });
-}
-
-function splitLocalHref(href) {
-  const hashIndex = href.indexOf("#");
-  if (hashIndex === -1) {
-    return { filePart: href, anchor: "" };
-  }
-  return {
-    filePart: href.slice(0, hashIndex),
-    anchor: href.slice(hashIndex + 1),
-  };
-}
-
-function resolveRepoRelative(currentRelPath, targetPath) {
-  const decoded = safeDecodeUrl(targetPath).replace(/\\/g, "/");
-  const currentDir = path.posix.dirname(currentRelPath);
-  return normalizeRelPath(path.posix.join(currentDir, decoded));
-}
-
-function resolveHref(href, currentRelPath) {
-  if (!href) return { href };
-  if (isExternalUrl(href)) return { href, external: true };
-
-  const { filePart, anchor } = splitLocalHref(href);
-  if (!filePart) {
-    const currentId = idFromRel(currentRelPath);
-    return {
-      href: `#/doc/${currentId}${anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""}`,
-      internal: true,
-    };
-  }
-
-  const targetRel = resolveRepoRelative(currentRelPath, filePart);
-  const lower = targetRel.toLowerCase();
-  if (lower.endsWith(".md")) {
-    if (isEnglishPath(targetRel)) {
-      return {
-        href: "#",
-        disabled: true,
-        title: "当前阅读器只收录 Markdown 正文",
-      };
-    }
-    return {
-      href: `#/doc/${idFromRel(targetRel)}${
-        anchor ? `?anchor=${encodeURIComponent(anchor)}` : ""
-      }`,
-      internal: true,
-    };
-  }
-
-  return { href: `/raw/${idFromRel(targetRel)}`, asset: true };
-}
-
-function addLinkAndImageResolvers(markdownIt) {
-  const defaultLinkOpen =
-    markdownIt.renderer.rules.link_open ||
-    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
-  const defaultImage =
-    markdownIt.renderer.rules.image ||
-    ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
-
-  markdownIt.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-    const token = tokens[idx];
-    const href = token.attrGet("href");
-    const resolved = resolveHref(href, env.relPath);
-    token.attrSet("href", resolved.href);
-    if (resolved.external) {
-      token.attrSet("target", "_blank");
-      token.attrSet("rel", "noopener noreferrer");
-    }
-    if (resolved.disabled) {
-      token.attrJoin("class", "disabled-link");
-      token.attrSet("aria-disabled", "true");
-      token.attrSet("title", resolved.title);
-    }
-    return defaultLinkOpen(tokens, idx, options, env, self);
-  };
-
-  markdownIt.renderer.rules.image = (tokens, idx, options, env, self) => {
-    const token = tokens[idx];
-    const src = token.attrGet("src");
-    if (src && !isExternalUrl(src)) {
-      const resolved = resolveHref(src, env.relPath);
-      token.attrSet("src", resolved.href);
-    }
-    token.attrSet("loading", "lazy");
-    return defaultImage(tokens, idx, options, env, self);
-  };
-}
-
-function transformRenderedHtml(html, currentRelPath) {
-  const $ = cheerio.load(html, { decodeEntities: false }, false);
-
-  $("img, source").each((_, element) => {
-    const node = $(element);
-    const attrName = node.attr("src") ? "src" : "srcset";
-    const value = node.attr(attrName);
-    if (!value || isExternalUrl(value) || value.startsWith("/raw/")) return;
-    const resolved = resolveHref(value, currentRelPath);
-    node.attr(attrName, resolved.href);
-    if (element.tagName === "img" && !node.attr("loading")) {
-      node.attr("loading", "lazy");
-    }
-  });
-
-  $("a").each((_, element) => {
-    const node = $(element);
-    const href = node.attr("href");
-    if (!href || href.startsWith("#/doc/") || href.startsWith("/raw/")) return;
-    const resolved = resolveHref(href, currentRelPath);
-    node.attr("href", resolved.href);
-    if (resolved.external) {
-      node.attr("target", "_blank");
-      node.attr("rel", "noopener noreferrer");
-    }
-    if (resolved.disabled) {
-      node.addClass("disabled-link");
-      node.attr("aria-disabled", "true");
-      node.attr("title", resolved.title);
-    }
-  });
-
-  $("table").each((_, element) => {
-    const table = $(element);
-    if (!table.parent().hasClass("table-wrap")) {
-      table.wrap('<div class="table-wrap"></div>');
-    }
-  });
-
-  return $.html();
-}
-
-function groupForDoc(relPath) {
-  if (relPath === "README.md") {
-    return {
-      key: "__root__",
-      title: "项目首页",
-      sortTitle: "00-项目首页",
-    };
-  }
-  const first = relPath.split("/")[0];
-  return {
-    key: first,
-    title: formatSegmentTitle(first),
-    sortTitle: first,
-  };
-}
-
-function catalogSortPath(relPath) {
-  return relPath === "README.md" ? "00-README.md" : relPath;
-}
-
-async function collectDocs() {
-  const files = await walkMarkdownFiles();
-  const docs = [];
-
-  for (const relPath of files) {
-    const markdown = await readUtf8(relPath);
-    if (!hasChineseText(markdown)) continue;
-
-    const group = groupForDoc(relPath);
-    const title = extractHeadingTitle(markdown) || titleFromPath(relPath);
-    docs.push({
-      id: idFromRel(relPath),
-      relPath,
-      title,
-      groupKey: group.key,
-      groupTitle: group.title,
-      groupSortTitle: group.sortTitle,
-      excerpt: extractExcerpt(markdown),
-      depth: Math.max(0, relPath.split("/").length - 1),
-      dirname: path.posix.dirname(relPath) === "." ? "" : path.posix.dirname(relPath),
-    });
-  }
-
-  docs.sort((left, right) =>
-    collator.compare(catalogSortPath(left.relPath), catalogSortPath(right.relPath)),
-  );
-
-  docs.forEach((doc, index) => {
-    doc.order = index + 1;
-    doc.previousId = docs[index - 1]?.id || "";
-    doc.nextId = docs[index + 1]?.id || "";
-  });
-
-  const groupMap = new Map();
-  for (const doc of docs) {
-    if (!groupMap.has(doc.groupKey)) {
-      groupMap.set(doc.groupKey, {
-        key: doc.groupKey,
-        title: doc.groupTitle,
-        sortTitle: doc.groupSortTitle,
-        docs: [],
-      });
-    }
-    groupMap.get(doc.groupKey).docs.push(doc);
-  }
-
-  const groups = Array.from(groupMap.values()).sort((left, right) =>
-    collator.compare(left.sortTitle, right.sortTitle),
-  );
-
-  return {
-    generatedAt: new Date().toISOString(),
-    project: {
-      title: "Every-Embodied 电子书",
-      subtitle: "从 0 构建自己的具身智能机器人",
-      cover: fsSync.existsSync(fullPathFromRel("assets/main.png"))
-        ? rawHrefFromRel("assets/main.png")
-        : "",
-      hero: fsSync.existsSync(fullPathFromRel("assets/main.png"))
-        ? rawHrefFromRel("assets/main.png")
-        : "",
-      homepageHero: fsSync.existsSync(fullPathFromRel("assets/首页背景图.png"))
-        ? rawHrefFromRel("assets/首页背景图.png")
-        : "",
-      logo: fsSync.existsSync(fullPathFromRel("assets/头像 logo.jpg"))
-        ? rawHrefFromRel("assets/头像 logo.jpg")
-        : "",
-      favicon: fsSync.existsSync(fullPathFromRel("assets/线稿.png"))
-        ? rawHrefFromRel("assets/线稿.png")
-        : "",
-      map: fsSync.existsSync(fullPathFromRel("map.png")) ? rawHrefFromRel("map.png") : "",
-    },
-    stats: {
-      docs: docs.length,
-      groups: groups.length,
-    },
-    groups,
-    docs,
-  };
-}
-
 const app = express();
 
-app.get("/api/docs", async (_request, response, next) => {
+app.get("/favicon.png", (_request, response, next) => {
   try {
-    response.json(await collectDocs());
+    response.sendFile(fullPathFromRel("assets/线稿.png"));
   } catch (error) {
     next(error);
   }
 });
 
-app.get("/api/github", async (_request, response, next) => {
+app.get("/data/catalog.json", async (_request, response, next) => {
+  try {
+    response.json(await collectCatalog());
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get("/data/github.json", async (_request, response, next) => {
   try {
     const now = Date.now();
     if (githubRepoCache.value && githubRepoCache.expiresAt > now) {
@@ -627,24 +45,8 @@ app.get("/api/github", async (_request, response, next) => {
       return;
     }
 
-    const githubResponse = await fetch("https://api.github.com/repos/datawhalechina/every-embodied", {
-      headers: {
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "every-embodied-reader",
-      },
-    });
-
-    if (!githubResponse.ok) {
-      throw new Error(`GitHub API returned ${githubResponse.status}`);
-    }
-
-    const repo = await githubResponse.json();
     githubRepoCache = {
-      value: {
-        stars: repo.stargazers_count,
-        forks: repo.forks_count,
-        updatedAt: repo.updated_at,
-      },
+      value: await fetchGithubRepo(),
       expiresAt: now + 5 * 60 * 1000,
     };
     response.json(githubRepoCache.value);
@@ -653,32 +55,24 @@ app.get("/api/github", async (_request, response, next) => {
   }
 });
 
-app.get("/api/doc/:id", async (request, response, next) => {
+app.get("/data/docs/:id.json", async (request, response, next) => {
   try {
-    const relPath = relFromId(request.params.id);
-    const catalog = await collectDocs();
-    const doc = catalog.docs.find((item) => item.relPath === relPath);
-    if (!doc) {
+    const catalog = await collectCatalog();
+    const relPath = catalog.docs.find((item) => item.id === request.params.id)?.relPath;
+    if (!relPath) {
       response.status(404).json({ error: "Document not found in Chinese catalog" });
       return;
     }
 
-    const markdown = await readUtf8(relPath);
-    const displayMarkdown = removeTopAuthorMetadata(markdown);
-    const rendered = md.render(displayMarkdown, { relPath });
-    response.json({
-      ...doc,
-      html: transformRenderedHtml(rendered, relPath),
-      headings: extractHeadings(displayMarkdown),
-    });
+    response.json(await buildDocPayload(relPath, catalog));
   } catch (error) {
     next(error);
   }
 });
 
-app.get("/raw/:id", (request, response, next) => {
+app.get("/files/*", (request, response, next) => {
   try {
-    const relPath = relFromId(request.params.id);
+    const relPath = normalizeRelPath(decodeURIComponent(request.params[0]));
     response.sendFile(fullPathFromRel(relPath));
   } catch (error) {
     next(error);


### PR DESCRIPTION
## Summary
- convert the ebook site to a static GitHub Pages build under zh-cn/
- add a shared content pipeline for catalog/doc generation and asset rewriting
- add a GitHub Actions Pages workflow with push and manual deploy triggers

## Verification
- node --check web/lib/content.js
- node --check web/server.js
- node --check web/public/app.js
- node --check scripts/build-pages.js
- npm run build:pages
