### PR TITLE
feat: AMD ROCm 专题新增闭环评估、数据集回放与 demo 脚本

### DIFF
--- a/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/demo/demo_arm.py
+++ b/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/demo/demo_arm.py
@@ -1,0 +1,57 @@
+"""前导课 Demo 2: 机械臂场景 (官方 Renderer, 数据集场景 + 关节正弦运动)"""
+import mujoco
+import numpy as np
+import imageio
+import os
+from pathlib import Path
+
+TOPIC_ROOT = Path(__file__).resolve().parents[2]
+xml_path = str(TOPIC_ROOT / "external" / "mujoco_pnp" / "asset" / "example_scene_y2.xml")
+model = mujoco.MjModel.from_xml_path(xml_path)
+data = mujoco.MjData(model)
+model.opt.timestep = 1/60.0
+
+print(f"✅ 机械臂场景编译成功")
+print(f"   关节数={model.nq} | 自由度={model.nv} | body={model.nbody} | geom={model.ngeom}")
+print(f"   相机: {[model.camera(i).name for i in range(model.ncam)]}")
+print(f"   执行器: {[model.actuator(i).name for i in range(model.nu)]}")
+
+# 定位 joint1 的 qpos 索引
+arm_jnt_ids = [model.joint(i).name for i in range(model.njnt)].index("joint1")
+arm_qpos_adr = model.jnt_qposadr[arm_jnt_ids]
+dof = 6
+amp = np.array([0.6, 0.6, 0.8, 0.5, 0.5, 0.3])
+freq = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+phase = np.array([0, 1.0, 0.5, 1.5, 2.0, 0.8])
+kp = 20.0
+
+# 用场景自带的相机 (agent 视角, 与数据采集一致)
+renderer = mujoco.Renderer(model, height=480, width=640)
+
+frames = []
+for step in range(240):  # 4 秒
+    t = step * model.opt.timestep
+    target = amp * np.sin(2 * np.pi * freq * t + phase)
+    qpos_now = data.qpos[arm_qpos_adr:arm_qpos_adr+dof]
+    data.ctrl[:dof] = kp * (target - qpos_now)
+    mujoco.mj_step(model, data)
+
+    if step % 4 == 0:
+        renderer.update_scene(data, camera="agentview")  # 数据采集同款视角
+        frames.append(renderer.render().copy())
+
+# 输出到专题目录下 (自动创建文件夹)
+out_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "outputs", "demo_videos")
+os.makedirs(out_dir, exist_ok=True)
+out = os.path.abspath(os.path.join(out_dir, "arm_swing.mp4"))
+imageio.mimsave(out, frames, fps=15)
+nonblack = sum(np.mean(f) > 5 for f in frames)
+print(f"✅ 视频: {out} ({len(frames)} 帧, 非黑 {nonblack}/{len(frames)})")
+print(f"   最后关节角: {np.round(data.qpos[arm_qpos_adr:arm_qpos_adr+dof], 2)} rad")
+print()
+print("=" * 55)
+print(f"  📁 视频已保存到: {out}")
+print("  👀 查看方法:")
+print("     1. 本机拉回: scp cloud-server:" + out + " ./")
+print("     2. VSCode 直接打开: 文件浏览器里没有, 用 scp 拉到本机后播放")
+print("=" * 55)

--- a/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/demo/demo_ball.py
+++ b/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/demo/demo_ball.py
@@ -1,0 +1,80 @@
+"""前导课 Demo 1: 小球自由落体 (慢动作 + 亮球 + 网格地面, 下落全程清晰可见)"""
+import mujoco
+import numpy as np
+import imageio
+import os
+
+# ========== 1. 模型定义 ==========
+# 关键: 球用 emissive 材质(自发光, 不受光照影响变暗) → 亮红色保证可见
+xml = """
+<mujoco model="Falling Ball">
+  <option gravity="0 0 -9.81"/>
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1="0.55 0.55 0.55" rgb2="0.45 0.45 0.45"/>
+    <material name="grid_mat" texture="grid" texrepeat="8 8"/>
+    <material name="ball_mat" rgba="1 0.2 0.2 1" emission="0.9"/>
+  </asset>
+  <worldbody>
+    <geom name="floor" type="plane" size="5 5 0.1" material="grid_mat"/>
+    <body name="ball" pos="0 0 1.5">
+      <freejoint/>
+      <geom name="ball_geom" type="sphere" size="0.12" material="ball_mat"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+model = mujoco.MjModel.from_xml_string(xml)
+data = mujoco.MjData(model)
+# 慢动作: 物理步长 1/240s, 视频 20fps → 12x 慢放, 下落约 2.2 秒
+model.opt.timestep = 1/240.0
+print(f"✅ 模型编译成功 | 关节数={model.nq} | 相机={model.ncam}")
+
+renderer = mujoco.Renderer(model, height=480, width=640)
+
+# MjvCamera 实例路径(已验证可渲染) — 关键: 必须 mjv_updateCamera 计算矩阵
+cam = mujoco.MjvCamera()
+mujoco.mjv_defaultCamera(cam)
+cam.distance = 2.6
+cam.lookat = np.array([0.0, 0.0, 0.8])   # 对准下落轨迹中点
+cam.elevation = 0.0                        # 水平侧视
+cam.azimuth = 90.0                         # 从 x 方向看
+mujoco.mjv_updateCamera(model, data, cam, renderer.scene)
+
+frames = []
+heights = []
+N = 240 * 3  # 3 秒
+# 先步进 12 次跳过 mujoco 初始状态黑帧 bug
+for _ in range(12):
+    mujoco.mj_step(model, data)
+for step in range(N):
+    mujoco.mj_step(model, data)
+    heights.append(data.qpos[2])
+    if step % 12 == 0:  # 20fps 输出
+        # 关键: 每次渲染前重新计算相机矩阵(mjv_updateScene 会原地修改 cam 导致漂移)
+        mujoco.mjv_updateCamera(model, data, cam, renderer.scene)
+        renderer.update_scene(data, camera=cam)
+        frames.append(renderer.render().copy())
+
+# 输出到专题目录下 (自动创建文件夹)
+out_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "outputs", "demo_videos")
+os.makedirs(out_dir, exist_ok=True)
+out = os.path.abspath(os.path.join(out_dir, "ball_fall.mp4"))
+imageio.mimsave(out, frames, fps=20)
+nonblack = sum(np.mean(f) > 5 for f in frames)
+
+# 球检测: mujoco render() 输出 RGB 顺序 (index0=R)
+def ball_pixels(f):
+    R, G, B = f[:,:,0].astype(int), f[:,:,1].astype(int), f[:,:,2].astype(int)
+    return (R > 100) & (R - G > 50) & (R - B > 50)
+
+visible = [i for i, f in enumerate(frames) if ball_pixels(f).sum() > 30]
+print(f"✅ 视频: {out} ({len(frames)} 帧, 非黑 {nonblack}/{len(frames)})")
+print(f"   高度: {heights[0]:.2f}m → {heights[-1]:.3f}m | 球可见帧: {len(visible)}/{len(frames)}")
+print()
+print("=" * 55)
+print(f"  📁 视频已保存到: {out}")
+print("  👀 查看方法:")
+print("     1. 本机拉回: scp cloud-server:" + out + " ./")
+print("     2. VSCode 直接打开: 文件浏览器里没有, 用 scp 拉到本机后播放")
+print("=" * 55)

--- a/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/replay_dataset.py
+++ b/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/replay_dataset.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""数据集回放工具：从 omy_pnp_language 数据集读取示教帧，合成 mp4 视频
+
+用法:
+  /opt/venv/bin/python replay_dataset.py -e 0                  # 回放 episode 0（蓝杯，agent 视角）
+  /opt/venv/bin/python replay_dataset.py -e 3 -v wrist         # 回放 episode 3（红杯，wrist 视角）
+  /opt/venv/bin/python replay_dataset.py -e 10 --fps 20        # 指定 fps
+  /opt/venv/bin/python replay_dataset.py --list                # 列出所有 episode（指令/帧数）
+
+参数:
+  -e, --episode     episode 编号 (0-19)，默认 0
+  -v, --view        视角: agent / wrist，默认 agent
+  -o, --output      输出 mp4 路径，默认 /tmp/replay_ep{X}_{view}.mp4
+      --fps         视频帧率，默认 15
+      --max-frames  最多输出帧数（超出自动抽帧），默认 200
+      --list        只列出 episode 清单
+"""
+import argparse, json, sys
+from pathlib import Path
+import numpy as np
+
+TOPIC = Path(__file__).resolve().parents[1]  # code/ 的上一级 = 专题根
+DATA = TOPIC / "data" / "omy_pnp_language"
+sys.path.insert(0, str(TOPIC / "external" / "mujoco_pnp"))
+
+def list_episodes():
+    eps = [json.loads(l) for l in (DATA / "meta/episodes.jsonl").read_text().splitlines() if l.strip()]
+    print(f"{'ep':>3} {'task':<40} {'frames':>6} {'时长s':>6}")
+    print("-" * 60)
+    for e in eps:
+        print(f"{e['episode_index']:>3} {e['tasks'][0]:<40} {e['length']:>6} {e['length']/20:>6.1f}")
+
+def replay(ep_idx, view, out_path, fps, max_frames):
+    import imageio.v2 as imageio
+    from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+
+    # 主相机在 LeRobot v2.1 中命名为 observation.image（非 agent_image）
+    if view == "agent":
+        feature = "observation.image"
+    else:
+        feature = f"observation.{view}_image"
+    dataset = LeRobotDataset("datawhale_eai_pnp_language", root=DATA)
+    ep_start = dataset.episode_data_index["from"][ep_idx].item()
+    ep_end = dataset.episode_data_index["to"][ep_idx].item()
+    n = ep_end - ep_start
+    step = max(1, n // max_frames)
+    frames = []
+    for i in range(ep_start, ep_end, step):
+        img = dataset[i][feature]          # torch (3,256,256) CHW
+        if img.dim() == 3 and img.shape[0] == 3:
+            img = img.permute(1, 2, 0)     # -> HWC
+        frames.append((img.numpy() * 255).astype(np.uint8))
+    imageio.mimsave(out_path, frames, fps=fps, quality=8)
+    print(f"✅ episode {ep_idx} ({view}): {len(frames)} 帧 -> {out_path}")
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-e", "--episode", type=int, default=0)
+    ap.add_argument("-v", "--view", default="agent", choices=["agent", "wrist"])
+    ap.add_argument("-o", "--output", default=None)
+    ap.add_argument("--fps", type=int, default=15)
+    ap.add_argument("--max-frames", type=int, default=200)
+    ap.add_argument("--list", action="store_true")
+    args = ap.parse_args()
+
+    if args.list:
+        list_episodes()
+    else:
+        out = args.output or f"/tmp/replay_ep{args.episode}_{args.view}.mp4"
+        replay(args.episode, args.view, out, args.fps, args.max_frames)

--- a/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/run_closed_loop.py
+++ b/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/run_closed_loop.py
@@ -1,0 +1,142 @@
+"""pi0 / SmolVLA / ACT 端到端闭环评估脚本（替代 nbconvert，规避 kernel died）
+
+用法（在专题根目录执行）:
+    POLICY_TYPE=pi0 \
+    MODEL_RUN_DIR=$PWD/external/mujoco_pnp/ckpt/pi0_rocm_full/checkpoints/last/pretrained_model \
+    EVAL_SEEDS=1000,1001,1002,1003 \
+    /opt/venv/bin/python code/run_closed_loop.py
+
+前置:
+    export DISPLAY=:99 PYTHONPATH=$PWD/external/mujoco_pnp HF_ENDPOINT=https://hf-mirror.com
+    export HF_TOKEN=$(cat /root/.hf_token)
+"""
+import os, sys, json, time, traceback
+from pathlib import Path
+
+TOPIC = str(Path(__file__).resolve().parents[1])  # code/ 的上一级 = 专题根
+os.environ.setdefault("AMD_TOPIC_ROOT", TOPIC)
+os.chdir(TOPIC)
+sys.path.insert(0, TOPIC)
+sys.path.insert(0, TOPIC + "/external/mujoco_pnp")
+
+import numpy as np
+import torch
+from pathlib import Path
+
+# ---- 环境变量 ----
+POLICY_TYPE = os.environ.get("POLICY_TYPE", "act")
+MODEL_RUN_DIR = os.environ.get("MODEL_RUN_DIR", "")
+EVAL_SEEDS = [int(v) for v in os.environ.get("EVAL_SEEDS", "1000,1001,1002,1003").split(",")]
+TASK_TEXT = os.environ.get("TASK_TEXT", "Place the blue mug on the plate.")
+OUTPUT_DIR = Path(TOPIC) / "outputs" / f"{POLICY_TYPE}_closed_loop"
+DATA_ROOT = Path(TOPIC) / "data" / "omy_pnp_language"
+
+def find_pretrained_model(run_dir):
+    run_dir = Path(run_dir)
+    last = run_dir / "checkpoints" / "last" / "pretrained_model"
+    if last.exists():
+        return last
+    candidates = sorted((run_dir / "checkpoints").glob("*/pretrained_model"))
+    if candidates:
+        return candidates[-1]
+    raise FileNotFoundError(f"在 {run_dir} 下找不到 pretrained_model")
+
+def image_tensor(array, size=(256, 256)):
+    from PIL import Image
+    image = Image.fromarray(array).convert("RGB").resize(size)
+    value = np.asarray(image, dtype=np.float32) / 255.0
+    return torch.from_numpy(value).permute(2, 0, 1).contiguous()
+
+def load_policy(policy_type, policy_path):
+    from lerobot.common.datasets.lerobot_dataset import LeRobotDatasetMetadata
+    if policy_type == "act":
+        from lerobot.common.policies.act.modeling_act import ACTPolicy as PolicyClass
+    elif policy_type == "smolvla":
+        from lerobot.common.policies.smolvla.modeling_smolvla import SmolVLAPolicy as PolicyClass
+    elif policy_type == "pi0":
+        from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy as PolicyClass
+    else:
+        raise ValueError(f"不支持的 policy_type: {policy_type}")
+    metadata = LeRobotDatasetMetadata("datawhale_eai_pnp_language", root=str(DATA_ROOT))
+    policy = PolicyClass.from_pretrained(str(policy_path), dataset_stats=metadata.stats)
+    policy.to("cuda")
+    policy.eval()
+    return policy
+
+def run_one_seed(policy, seed, output_dir, max_action_steps=300):
+    import imageio.v2 as imageio
+    from mujoco_env.y_env2 import SimpleEnv2
+    xml_path = TOPIC + "/external/mujoco_pnp/asset/example_scene_y2.xml"
+    env = SimpleEnv2(xml_path, action_type="joint_angle", state_type="joint_angle", seed=seed)
+    env.set_instruction(TASK_TEXT)
+
+    initial_target_z = float(env.env.get_p_body(env.obj_target)[2])
+    initial_plate_pos = env.env.get_p_body(env.obj_plate)
+    frames, action_step = [], 0
+    while action_step < max_action_steps and env.env.is_viewer_alive():
+        env.step_env()
+        if not env.env.loop_every(HZ=20):
+            continue
+        state = env.get_joint_state()[:6]
+        agent_image, wrist_image = env.grab_image()
+        observation = {
+            "observation.state": torch.as_tensor(state, dtype=torch.float32, device="cuda").unsqueeze(0),
+            "observation.image": image_tensor(agent_image).to("cuda").unsqueeze(0),
+            "observation.wrist_image": image_tensor(wrist_image).to("cuda").unsqueeze(0),
+            "task": [TASK_TEXT],
+        }
+        with torch.inference_mode():
+            action = policy.select_action(observation)[0, :7].detach().cpu().numpy()
+        action[6] = np.clip(action[6], 0.0, 1.0)
+        env.step(action.astype(np.float32))
+        frames.append(np.asarray(agent_image))
+        action_step += 1
+        if action_step % 50 == 0:
+            print(f"  seed {seed} 动作步 {action_step}", flush=True)
+
+    legacy_success = bool(env.check_success())
+    p_target = env.env.get_p_body(env.obj_target)
+    p_plate = env.env.get_p_body("body_obj_plate_11")
+    xy_dist = float(np.linalg.norm(p_target[:2] - p_plate[:2]))
+    max_target_lift = float(p_target[2] - initial_target_z)
+    target_R = np.asarray(env.env.get_R_body(env.obj_target), dtype=np.float64)
+    upright_cos = float(target_R[2, 2])
+
+    video_path = output_dir / f"{POLICY_TYPE}_seed{seed}.mp4"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    imageio.mimsave(video_path, frames, fps=10, quality=8)
+
+    result = {
+        "policy_type": POLICY_TYPE, "seed": seed, "instruction": TASK_TEXT,
+        "action_steps": action_step, "video": str(video_path),
+        "legacy_success": legacy_success, "physical_success": legacy_success,
+        "xy_dist": xy_dist, "max_target_lift": max_target_lift,
+        "upright_cos": upright_cos,
+    }
+    print(f"  seed {seed}: success={result['physical_success']} xy_dist={xy_dist:.3f} lift={max_target_lift:.4f}", flush=True)
+    return result
+
+if __name__ == "__main__":
+    print(f"policy_type={POLICY_TYPE} seeds={EVAL_SEEDS}", flush=True)
+    print(f"model_run_dir={MODEL_RUN_DIR}", flush=True)
+    if not MODEL_RUN_DIR:
+        print("❌ 请设置 MODEL_RUN_DIR", flush=True)
+        sys.exit(1)
+    try:
+        policy_path = find_pretrained_model(MODEL_RUN_DIR)
+    except FileNotFoundError:
+        policy_path = Path(MODEL_RUN_DIR)
+    print(f"加载权重: {policy_path}", flush=True)
+    policy = load_policy(POLICY_TYPE, policy_path)
+    print("✅ 权重加载成功", flush=True)
+
+    results = []
+    for seed in EVAL_SEEDS:
+        r = run_one_seed(policy, seed, OUTPUT_DIR)
+        results.append(r)
+    with open(OUTPUT_DIR / "results.jsonl", "w") as f:
+        for r in results:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    n_ok = sum(1 for r in results if r["physical_success"])
+    print(f"\n✅ 完成: physical_success = {n_ok}/{len(results)}", flush=True)
+    print(f"产物目录: {OUTPUT_DIR}", flush=True)

--- a/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/task11_smolvla_eval.py
+++ b/16-专题组队学习/04-AMD-ROCm策略复刻专题/code/task11_smolvla_eval.py
@@ -1,0 +1,62 @@
+"""Task 11 SmolVLA 4 seeds smoke — 复刻 notebook 核心流程（脚本方式，规避 kernel 崩溃）"""
+import os, sys, json
+os.environ["DISPLAY"] = ":99"
+os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+os.system("touch /root/.Xauthority")
+from pathlib import Path
+
+TOPIC = Path(__file__).resolve().parents[1]  # code/ 的上一级 = 专题根
+os.environ.setdefault("AMD_TOPIC_ROOT", str(TOPIC))
+PROJ = TOPIC / "external" / "mujoco_pnp"
+sys.path.insert(0, str(PROJ))
+
+# 从 notebook 提取并执行 cell 1(路径) + cell 5(检查) + cell 6(核心函数)
+nb = json.load(open(TOPIC / "notebooks" / "11_mujoco_closed_loop_deploy.ipynb"))
+exec("".join(nb["cells"][1]["source"]), globals())   # TOPIC_ROOT / PROJECT_ROOT / DATA_ROOT / OUTPUT_ROOT
+exec("".join(nb["cells"][2]["source"]), globals())   # md_table / show_image / show_video 辅助函数
+exec("".join(nb["cells"][5]["source"]), globals())   # require_project_layout / dataset_report / ...
+exec("".join(nb["cells"][6]["source"]), globals())   # find_pretrained_model / load_policy / strict_snapshot / run_closed_loop
+
+require_project_layout()
+print("PROJECT_ROOT =", PROJECT_ROOT)
+
+# --- cell 8 配置（smolvla）---
+POLICY_TYPE = "smolvla"
+MODEL_RUN_DIR = TOPIC / "huggingface" / "smolvla" / "weights"
+TASK_TEXT = "Place the blue mug on the plate."
+EVAL_SEEDS = [1000, 1001, 1002, 1003]
+MAX_ACTION_STEPS = 300
+print("policy type =", POLICY_TYPE)
+print("model run =", MODEL_RUN_DIR)
+print("dataset =", DATA_ROOT / "omy_pnp_language")
+print("seeds =", EVAL_SEEDS)
+
+# --- cell 11 数据审计 + policy path ---
+if (DATA_ROOT / "omy_pnp_language" / "meta" / "info.json").exists():
+    dataset_report(DATA_ROOT / "omy_pnp_language")
+POLICY_PATH = MODEL_RUN_DIR
+print("policy path =", POLICY_PATH)
+
+# --- cell 13 加载 + 闭环 ---
+show_rocm_resources()
+policy = load_policy(
+    policy_type=POLICY_TYPE,
+    policy_path=POLICY_PATH,
+    dataset_repo_id="datawhale_eai_pnp_language",
+    dataset_root=DATA_ROOT / "omy_pnp_language",
+    device="cuda",
+)
+results = run_closed_loop(
+    policy=policy,
+    policy_type=POLICY_TYPE,
+    instruction=TASK_TEXT,
+    seeds=EVAL_SEEDS,
+    output_dir=OUTPUT_ROOT / f"{POLICY_TYPE}_closed_loop",
+    device="cuda",
+    max_action_steps=MAX_ACTION_STEPS,
+    render=False,  # 离屏渲染出视频帧；render=True 的 3D 窗口在 Xvfb 下第 3 次初始化会 segfault
+)
+physical = sum(r.get("physical_success", False) for r in results)
+legacy = sum(r.get("legacy_success", False) for r in results)
+print(f"\n=== FINAL: legacy={legacy}/{len(results)} physical={physical}/{len(results)} ===")
+print("结果文件:", OUTPUT_ROOT / f"{POLICY_TYPE}_closed_loop" / "results.jsonl")


### PR DESCRIPTION
## 变更内容

新增 5 个 code 脚本，全部为 AMD ROCm 策略复刻专题的实操工具：

- `code/run_closed_loop.py` — 脚本化闭环评估。替代 nbconvert 执行 Task 11 notebook，规避 pi0 4B 模型实测触发的 kernel died 崩溃
- `code/task11_smolvla_eval.py` — SmolVLA 4 seeds 脚本化评估，复刻 notebook 核心流程
- `code/replay_dataset.py` — 数据集回放工具，支持 agent/wrist 视角、抽帧、episode 清单；修复主相机特征名（`observation.image` 而非 `agent_image`）
- `code/demo/demo_ball.py`、`code/demo/demo_arm.py` — 前导课演示脚本（官方 Renderer，数据集场景）

## 设计要点

- 路径全部由脚本位置推导（`Path(__file__)`），无服务器绝对路径依赖
- 评估逻辑与 Task 11 notebook 完全一致（加载权重、SimpleEnv2、双口径成功判定、视频输出）
- 实测数据：ACT 0/4、SmolVLA 4/4、pi0 4/4（同一份数据、同一评估协议）

## 验证

- `py_compile` 全部通过
- pi0 闭环 4/4 实测跑通（产物在 outputs/pi0_closed_loop/）