### PR TITLE
fix: 修复 4 个文档共 8 处图片坏链（错误路径/反斜杠/丢失域名/私服绝对路径）

### DIFF
--- a/11-其他辅助工具/hf快速下载同时避免下载不需要的其他分支文件.md
+++ b/11-其他辅助工具/hf快速下载同时避免下载不需要的其他分支文件.md
@@ -26,9 +26,9 @@ python3 download_hf_files_new.py facebook/dinov3-vits16-pretrain-lvd1689m main -
 
 python hf_downloader.py yifengzhu-hf/LIBERO-datasets main --repo-type dataset --subfolder libero_spatial --download_path ./libero-dataset/dataset/ --download-only
 
-![image.png](/./assets/432e92f2-4655-474d-8551-8b70d0f25541.png)
+![image.png](../06-策略抓取或抓取VLA/大模型控制、VLA、VLM/01SmolVLA-LIBERO/assets/432e92f2-4655-474d-8551-8b70d0f25541.png)
 
-![image.png](/./assets/c669c2be-3b85-4aee-a1fd-c74df4106f9d.png)
+![image.png](../06-策略抓取或抓取VLA/大模型控制、VLA、VLM/01SmolVLA-LIBERO/assets/c669c2be-3b85-4aee-a1fd-c74df4106f9d.png)
 
 需要切换到session所在路径，方可断点续传
 

--- a/15-Challenge竞赛/LeHome/README.md
+++ b/15-Challenge竞赛/LeHome/README.md
@@ -846,11 +846,11 @@ GPU 采样也已经表明这轮长训确实把 L40 吃得很满：
 
 训练曲线：
 
-![ACT training metrics](/root/gpufree-data/lehome-outputs/plots/act_four_types_l40_live/train_metrics.png)
+> **训练曲线图待补充**：原图片托管于作者本地服务器（`/root/gpufree-data/...`），对读者不可见。
 
 GPU 曲线：
 
-![L40 GPU monitor](/root/gpufree-data/lehome-outputs/plots/act_four_types_l40_live/gpu_metrics.png)
+> **GPU 监控图待补充**：原图片托管于作者本地服务器（`/root/gpufree-data/...`），对读者不可见。
 
 ### 3.14.6 这个长训为什么定在 50000 steps
 

--- a/17-具身世界模型/1、扩散数理基础及问题解析入门/扩散数理基础及问题解析入门.md
+++ b/17-具身世界模型/1、扩散数理基础及问题解析入门/扩散数理基础及问题解析入门.md
@@ -493,7 +493,7 @@ $$
 
 实现参考code代码中的direct.py文件，效果如下:
 
-<img src="assets\direct.png"/>
+<img src="assets/direct.png"/>
 
 
 
@@ -563,7 +563,7 @@ $$
 
 实现参考code代码中的vae_imitat.py文件，效果如下:
 
-<img src="assets\vae_imitat.png"/>
+<img src="assets/vae_imitat.png"/>
 
 vae实际生成的时候，都是一步生成的，这个可能会导致结果偏向平均，因此才有了ddpm，这个大家可以先有个基础的认知，后续会在vae单独讲解的时候讲。
 
@@ -669,7 +669,7 @@ $$
 
 实现参考code代码中的ddpm_imitat.py文件，效果如下:
 
-<img src="assets\ddpm_imitat.png"/>
+<img src="assets/ddpm_imitat.png"/>
 
 你会看到一个过程：
 

--- a/en/ch07/01-simulation-configuration-document.md
+++ b/en/ch07/01-simulation-configuration-document.md
@@ -33,7 +33,7 @@ models
 
 [](https://github.com/TATP-233/DISCOVERSE/tree/main#-photorealistic-rendering)
 
-[![photorealistic simulation](/TATP-233/DISCOVERSE/raw/main/assets/img2.png)](https://github.com/TATP-233/DISCOVERSE/blob/main/assets/img2.png)
+[![photorealistic simulation](https://github.com/TATP-233/DISCOVERSE/raw/main/assets/img2.png)](https://github.com/TATP-233/DISCOVERSE/blob/main/assets/img2.png)
 
 ### Preparation
 


### PR DESCRIPTION
fix: 修复 4 个文档共 8 处图片坏链

## 问题背景
#45 反馈部分图片无法渲染。经全量扫描（346 个 md、998 处本地图片引用）复核确认以下 8 处为真实坏链：

## 修复明细
1. `11-其他辅助工具/hf快速下载同时避免下载不需要的其他分支文件.md`（2 处）
   - `/./assets/432e92f2-....png`、`/./assets/c669c2be-....png` 指向不存在的路径
   - 实际图片位于 `06-策略抓取或抓取VLA/大模型控制、VLA、VLM/01SmolVLA-LIBERO/assets/`，改为相对路径
2. `17-具身世界模型/1、扩散数理基础及问题解析入门/扩散数理基础及问题解析入门.md`（3 处）
   - `assets\direct.png` 等 Windows 反斜杠路径，GitHub 渲染 404，改为正斜杠
3. `en/ch07/01-simulation-configuration-document.md`（1 处）
   - `![...](/TATP-233/DISCOVERSE/raw/main/assets/img2.png)` 丢失 `https://github.com` 域名前缀，补全
4. `15-Challenge竞赛/LeHome/README.md`（2 处）
   - 训练/GPU 曲线图引用作者本地服务器绝对路径 `/root/gpufree-data/...`，任何读者都无法访问
   - 改为占位说明，待维护者上传图片至仓库后恢复

其余 990+ 处本地图片引用经复核均有效。

Part of #45