### PR TITLE
docs(VLA): 补全语言数据集获取说明

### DIFF
--- a/06-策略抓取或抓取VLA/大模型控制、VLA、VLM/04mujoco复现ACT、Pi0、SmolVLA/8.smolvla.ipynb
+++ b/06-策略抓取或抓取VLA/大模型控制、VLA、VLM/04mujoco复现ACT、Pi0、SmolVLA/8.smolvla.ipynb
@@ -143,7 +143,7 @@
     "'''\n",
     "If you want to use the collected dataset, please download it from Hugging Face.\n",
     "'''\n",
-    "!git clone https://huggingface.co/datasets/datawhale-eai/datawhale_eai_pnp_language"
+    "!git clone https://huggingface.co/datasets/Datawhale/datawhale_eai_pnp_language demo_data_language"
    ]
   },
   {

--- a/06-策略抓取或抓取VLA/大模型控制、VLA、VLM/04mujoco复现ACT、Pi0、SmolVLA/README.md
+++ b/06-策略抓取或抓取VLA/大模型控制、VLA、VLM/04mujoco复现ACT、Pi0、SmolVLA/README.md
@@ -160,32 +160,36 @@ dataloader = torch.utils.data.DataLoader(
 
 <img src="./media/data_v2.gif" width="480" height="360" controls></img>
 
-## 模型与数据集
-| Model 🤗                                                      | Dataset 🤗                                                    |
-| ------------------------------------------------------------ | ------------------------------------------------------------ |
-| [pi_0 finetuned](https://huggingface.co/Jeongeun/omy_pnp_pi0) | [dataset](https://huggingface.co/datasets/Jeongeun/omy_pnp_language) |
-| [smolvla finetuned](https://huggingface.co/Jeongeun/omy_pnp_smolvla) | 同上                                                         |
+### 获取语言条件数据
 
-th>
-  </tr>
-  <tr>
-    <td><a href="https://huggingface.co/datawhale-eai/pi0_datawhale_eai">pi_0 finetuned</a></td>
-    <td><a href="https://huggingface.co/datasets/datawhale-eai/datawhale_eai_pnp_language">datawhale_eai_pnp_language</a></td>
-  </tr>
-  <tr>
-    <td><a href="https://huggingface.co/datawhale-eai/smolvla_datawhale_eai">smolvla finetuned</a></td>
-    <td>同上</td>
-  </tr>
-</table>
+可以直接下载公开样例数据，以便先跑通 Pi0 或 SmolVLA：
+
+```bash
+git lfs install
+git clone https://huggingface.co/datasets/Datawhale/datawhale_eai_pnp_language demo_data_language
+```
+
+也可以运行 [5.language_env.ipynb](5.language_env.ipynb)，自行采集红杯和蓝杯两个任务的 20 条示教数据。Notebook 同样会把 LeRobot 格式的数据写入 `./demo_data_language`。
+
+配置中的两个字段含义不同：
+
+- `repo_id: datawhale_eai_pnp_language` 是 LeRobot 数据集的标识名，用于匹配本地 metadata 和统计信息。
+- `root: ./demo_data_language` 是实际数据目录。无论下载样例还是自行采集，只要数据位于该目录，都不需要修改现有配置。
+
+## 模型与数据集
+| Model 🤗 | Dataset 🤗 |
+| --- | --- |
+| [pi_0 finetuned](https://huggingface.co/Jeongeun/omy_pnp_pi0) | [公开样例数据](https://huggingface.co/datasets/Datawhale/datawhale_eai_pnp_language) |
+| [smolvla finetuned](https://huggingface.co/Jeongeun/omy_pnp_smolvla) | 同上 |
 
 ## 7. 训练与部署 pi_0
 - [train_model.py](train_model.py)：训练脚本
-- [pi0_datawhale_eai.yaml](pi0_datawhale_eai.yaml)：训练配置
+- [pi0_omy.yaml](pi0_omy.yaml)：训练配置
 - [7.pi0.ipynb](7.pi0.ipynb)：部署示例
 
 训练命令：
 ```bash
-python train_model.py --config_path pi0_datawhale_eai.yaml
+python train_model.py --config_path pi0_omy.yaml
 ```
 
 部署效果：
@@ -229,12 +233,12 @@ wandb:
 
 ## 8. 训练与部署 SmolVLA
 - [train_model.py](train_model.py)：训练脚本
-- [smolvla_datawhale_eai.yaml](smolvla_datawhale_eai.yaml)：训练配置
+- [smolvla_omy.yaml](smolvla_omy.yaml)：训练配置
 - [8.smolvla.ipynb](8.smolvla.ipynb)：部署示例
 
 训练命令：
 ```bash
-python train_model.py --config_path smolvla_datawhale_eai.yaml
+python train_model.py --config_path smolvla_omy.yaml
 ```
 
 部署效果：


### PR DESCRIPTION
## 问题

Issue #92 询问 `datawhale_eai_pnp_language` 应如何获得。当前教程仍存在几处不一致：

- README 只展示 `repo_id` 与本地 `root`，没有说明可下载公开样例或运行 Notebook 自行采集。
- README 和 `8.smolvla.ipynb` 指向 `datawhale-eai/datawhale_eai_pnp_language`，该地址当前返回 404；公开数据集实际位于 `Datawhale/datawhale_eai_pnp_language`。
- README 引用 `pi0_datawhale_eai.yaml` 与 `smolvla_datawhale_eai.yaml`，但仓库实际文件是 `pi0_omy.yaml` 与 `smolvla_omy.yaml`。
- 模型与数据集区域混入缺少起始标签的 HTML 片段，渲染结构不完整。

## 改动

- 增加两条明确路径：下载公开样例数据，或运行 `5.language_env.ipynb` 自行采集。
- 解释 LeRobot `repo_id` 与本地 `root` 的不同职责，并让两条路径统一落到 `./demo_data_language`。
- 将 README 与 SmolVLA Notebook 的 clone 地址统一为有效的 Datawhale 数据集地址。
- 清理损坏的模型/数据表，并移除当前返回 404 的模型和数据链接。
- 修正 Pi0、SmolVLA 配置文件链接及训练命令，使其与仓库现有文件一致。

## 验证

- `python3 -m json.tool 8.smolvla.ipynb`：通过，Notebook JSON 有效。
- 内容守卫：有效数据 URL 和 clone 目标存在；4 个本地配置/Notebook 链接存在；失效 URL、两个不存在的 YAML 文件名和损坏 `th>` 片段均为 0。
- `git diff --check` 与提交前 `git diff --cached --check`：通过。
- Hugging Face 页面核对：`Datawhale/datawhale_eai_pnp_language` 可访问并声明 20 个 episode、LeRobot v2.1 格式及同一 clone/config 用法；旧 `datawhale-eai/...` 页面返回 404。

完整站点构建未执行：`npm ci` 首先被本机内部 npm 镜像的 `SELF_SIGNED_CERT_IN_CHAIN` 阻断；切换 npm 官方 registry 后仍因本机 `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` 在安装依赖前停止。这是依赖获取环境失败，不是构建通过，也没有产生文档构建失败证据。

## 风险

- 未下载约 2.62k 帧的完整数据集，也未运行 Pi0/SmolVLA GPU 训练；本 PR 只验证获取入口、配置路径和文档一致性。
- 中文 Markdown 合并后会由仓库现有离线翻译流程增量更新英文文档；本 PR 不手工修改自动生成的 `en/`。

Refs #92
